### PR TITLE
Remove getting the app (FabricRuntime.GetActivationContext().ApplicationName) which is throwing error.

### DIFF
--- a/ServiceFabric.PubSubActors.Demo/TestClient/Program.cs
+++ b/ServiceFabric.PubSubActors.Demo/TestClient/Program.cs
@@ -28,10 +28,6 @@ namespace TestClient
 			var subStateless = GetSubStatelessProxy();
 			RegisterSubscribers(applicationName);
 
-			var app = FabricRuntime.GetActivationContext().ApplicationName;
-
-
-
 			while (true)
 			{
 				Console.Clear();


### PR DESCRIPTION
This line of code is throwing an error and at the same time the app variable is not really used so I just removed it from code.