### PR TITLE
Broker Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Service Fabric Pub/Sub (Not just for Actors anymore!)
-Do you want to create an Event Driven Architecture while using Azure Service Fabric?
-Do you need to reliably broadcast messages between Actors and Services?
-This code will help you do that.
+Do you want to create an Event Driven Architecture while using Azure Service Fabric?  
+Do you need to reliably broadcast messages between Actors and Services?  
+This code will help you do that.  
 It supports both Actors and Services as publishers and subscribers.
 
 ## Contribute!
-Contributions are welcome.
-Please upgrade the package version with a minor tick if there are no breaking changes. And add a line to the readme.md, stating the changes, e.g. 'upgraded to SF version x.y.z'.
-Doing so will allow me to simply accept the PR, which will automatically trigger the release of a new package.
+Contributions are welcome.  
+Please upgrade the package version with a minor tick if there are no breaking changes. And add a line to the readme.md, stating the changes, e.g. 'upgraded to SF version x.y.z'.  
+Doing so will allow me to simply accept the PR, which will automatically trigger the release of a new package.  
 Please also make sure all feature additions have a corresponding unit test.
 
 ## Release notes:
 
+- 8.1.0 Add `GetBrokerStatsAsync()` and `UnsubscribeByQueueNameAsync()` to `BrokerClient` to help with monitoring and managing the Broker Service.
 - 8.0.0 Major cleanup and usability improvements.  Replaced Helper classes with a single `BrokerClient`.  Removed obsolete code (BrokerActor, RelayBrokerActor, extension methods).  Removed the `ServiceFabric.PubSubActors.Interfaces` library.  Simplified the BrokerService interface.
 - 7.6.2 Fix routing key issue.
 - 7.6.1 Fix hashing helper null ref issue.
@@ -60,8 +61,8 @@ https://www.nuget.org/packages/ServiceFabric.PubSubActors
 
 
 
-Using this package you can reliably send messages from Publishers (Actors/Services) to many Subscribers (Actors/Services).
-This is done using an intermediate, which is the BrokerService.
+Using this package you can reliably send messages from Publishers (Actors/Services) to many Subscribers (Actors/Services).  
+This is done using an intermediate, which is the BrokerService.  
 Add this package to all Reliable Actor & Service projects that participate in the pub/sub messaging.
 
 
@@ -80,8 +81,8 @@ Add this package to all Reliable Actor & Service projects that participate in th
 ## How to use:
 
 
-Add a new Stateful Reliable Service project. Call it 'PubSubService' (optional).
-Add Nuget package 'ServiceFabric.PubSubActors' to the 'PubSubActor' project
+Add a new Stateful Reliable Service project. Call it 'PubSubService' (optional).  
+Add Nuget package 'ServiceFabric.PubSubActors' to the 'PubSubActor' project.  
 Replace the code of PubSubService with the following code:
 ```csharp
 internal sealed class PubSubService : BrokerService
@@ -123,15 +124,15 @@ brokerClient.PublishMessageAsync(new PublishedMessageOne { Content = "Hello PubS
 ```
 
 ### Subscribing to messages using Actors
-*Create a sample Actor that implements 'ISubscriberActor', to become a subscriber to messages.*
-In this example, the Actor called 'SubscribingActor' subscribes to messages of Type 'PublishedMessageOne'.
+*Create a sample Actor that implements 'ISubscriberActor', to become a subscriber to messages.*  
+In this example, the Actor called 'SubscribingActor' subscribes to messages of Type 'PublishedMessageOne'.  
 
-Add a Reliable Stateless Actor project called 'SubscribingActor'.
-Add Nuget package 'ServiceFabric.PubSubActors' to the 'SubscribingActor' project
+Add a Reliable Stateless Actor project called 'SubscribingActor'.  
+Add Nuget package 'ServiceFabric.PubSubActors' to the 'SubscribingActor' project.  
 Add a project reference to the shared data contracts library ('DataContracts').
 
-Open the file 'SubscribingActor.cs' and replace the contents with the code below.
-**notice that this Actor now implements 'ISubscriberActor' indirectly.**
+Open the file 'SubscribingActor.cs' and replace the contents with the code below.  
+**notice that this Actor implement 'ISubscriberActor'.**
 ```csharp
 [ActorService(Name = nameof(SubscribingActor))]
 [StatePersistence(StatePersistence.None)]
@@ -165,11 +166,11 @@ internal class SubscribingActor : Actor, ISubscriberActor
 
 ### Subscribing to messages using Services using our base class
 
-*Create a sample Service that extends SubscriberStatelessServiceBase.*
+*Create a sample Service that extends SubscriberStatelessServiceBase.*  
 In this example, the Service called 'SubscribingStatelessService' subscribes to messages of Type 'PublishedMessageOne' and 'PublishedMessageTwo'.
 
-Add a Reliable Stateless Service project called 'SubscribingStatelessService'.
-Add Nuget package 'ServiceFabric.PubSubActors'.
+Add a Reliable Stateless Service project called 'SubscribingStatelessService'.  
+Add Nuget package 'ServiceFabric.PubSubActors'.  
 Add a project reference to the shared data contracts library ('DataContracts').
 
 Now open the file SubscribingStatelessService.cs in the project 'SubscribingStatelessService' and replace the SubscribingStatelessService class with this code:
@@ -196,7 +197,7 @@ internal sealed class SubscribingStatelessService : SubscriberStatelessServiceBa
     }
 }
 ```
-The SubscriberStatelessServiceBase class automatically handles subscribing to the message types that were registered using the `Subscribe` attribute when the service is 'opened'.
+The SubscriberStatelessServiceBase class automatically handles subscribing to the message types that were registered using the `Subscribe` attribute when the service is 'opened'.  
 *To subscribe from a Stateful Service, extend `SubscriberStatefulServiceBase` instead of `SubscribingStatelessServiceBase`*
 
 ### Subscribing to messages using Services without using our base class
@@ -251,14 +252,14 @@ internal sealed class SubscribingStatelessService : StatelessService, ISubscribe
 }
 ```
 
-Once the service gets an endpoint, it will automatically create subscriptions for all methods annotated with the `Subscribe` attribute.
+Once the service gets an endpoint, it will automatically create subscriptions for all methods annotated with the `Subscribe` attribute.  
 For stateful services, use the `StatefulSubscriberServiceBootstrapper`.
 
 *Check the Demo project for a working reference implementation.*
 
 
 ## Routing
-**This experimental feature works only when using the `DefaultPayloadSerializer`.**
+**This experimental feature works only when using the `DefaultPayloadSerializer`.**  
 It adds support for an additional subscriber filter, based on message content.
 
 ### Example
@@ -276,7 +277,7 @@ public class Customer
     public string Name {get; set;}
 }
 ```
-And given a subscriber that is interested in Customers named 'Customer1'.
+And given a subscriber that is interested in Customers named 'Customer1'.  
 The subscription would be registered like this:
 
 ```csharp
@@ -285,6 +286,18 @@ await brokerClient.SubscribeAsync<CustomerMessage>(this, HandleMessageOne, routi
 
 The routing key is queried by using `JToken.SelectToken`. More info [here](https://www.newtonsoft.com/json/help/html/SelectToken.htm).
 
+## Monitoring the Broker
+The `BrokerClient` offers a way to get some basic information about what is going on in the BrokerService.  Calling `BrokerClient.GetBrokerStats()` provides a Dictionary with one item for each queue (subscription) that the Broker is managing.  The key is the name of the queue and the value is a list of QueueStat objects.  Each QueueStat object is a snapshot of the state of the queue at the time the request was made.  The QueueStat object includes the name of the service, the total number of messages received, the total number of messages delivered, and time the snapshot was taken.  The totals are cumulative from the moment the queue was created.
+
+A new snapshot is added each time `BrokerClient.GetBrokerStats()` is called, so the user has control over the polling frequency.  The `BrokerClient` keeps a fixed number of snapshots per queue defined by `BrokerClient.QueueStatCapacity`, which defaults to 100.  When the 101st snapshot is created, the oldest one will be trimmed from the list.
+
+What information can you get:
+* A list of all queues (subscriptions) and the subscriber services they serve.
+* The total number of messages received and delivered for each queue.
+* If the difference between the total received and the total delivered is growing, the queue is taking in messages faster than they can be delivered (or the subscriber is down).
+* With a little extra processing, the number of messages received and delivered in a given time period can be calculated.  A UI could graph this data to show the load on each queue over time.
+
+Armed with a list of queueNames, you can use `BrokerClient.UnsubscribeByQueueNameAsync()` to unsubscribe on behalf of another service.
 
 ## Upgrading to version 8
 Significant changes were made in v8.0.0, including breaking changes to interfaces and tools.

--- a/ServiceFabric.PubSubActors.Tests/GivenBrokerClientTests.cs
+++ b/ServiceFabric.PubSubActors.Tests/GivenBrokerClientTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ServiceFabric.PubSubActors.Helpers;
+using ServiceFabric.PubSubActors.State;
+
+namespace ServiceFabric.PubSubActors.Tests
+{
+    [TestClass]
+    public class GivenBrokerClientTests
+    {
+        [TestMethod]
+        public async Task WhenGetBrokerStatsIsEmpty_EmptyDictionaryIsReturned()
+        {
+            var brokerClient = new BrokerClient(new MockBrokerServiceLocatorMultiPartition(new List<IBrokerService>
+            {
+                new MockBrokerService(),
+                new MockBrokerService()
+            }));
+
+            var queueStats = await brokerClient.GetBrokerStatsAsync();
+            Assert.IsTrue(queueStats.Count == 0);
+        }
+
+        [TestMethod]
+        public async Task WhenGetBrokerStatsIsCalled_AggregatesBrokerStatsFromMultiplePartitions()
+        {
+            var brokerClient = new BrokerClient(new MockBrokerServiceLocatorMultiPartition());
+            var queueStats = await brokerClient.GetBrokerStatsAsync();
+            Assert.IsTrue(queueStats.Count == 2);
+            Assert.IsTrue(queueStats.ContainsKey("MessageOneQueue") && queueStats["MessageOneQueue"].Count == 1 && queueStats["MessageOneQueue"].First().TotalDelivered == 34);
+            Assert.IsTrue(queueStats.ContainsKey("MessageTwoQueue") && queueStats["MessageTwoQueue"].Count == 1 && queueStats["MessageTwoQueue"].First().TotalReceived == 500);
+        }
+
+        [TestMethod]
+        public async Task WhenGetBrokerStatsIsCalledAgain_StatsAreAddedToTheList()
+        {
+            var brokerClient = new BrokerClient(new MockBrokerServiceLocatorMultiPartition());
+            await brokerClient.GetBrokerStatsAsync();
+            var queueStats = await brokerClient.GetBrokerStatsAsync();
+            Assert.IsTrue(queueStats.Count == 2);
+            Assert.IsTrue(queueStats.ContainsKey("MessageOneQueue") && queueStats["MessageOneQueue"].Count == 2 && queueStats["MessageOneQueue"].Last().TotalDelivered == 39);
+            Assert.IsTrue(queueStats.ContainsKey("MessageTwoQueue") && queueStats["MessageTwoQueue"].Count == 2 && queueStats["MessageTwoQueue"].Last().TotalReceived == 510);
+        }
+
+        [TestMethod]
+        public async Task WhenGetQueueCapacityIsExceeded_OldestStatsAreTrimmed()
+        {
+            var brokerClient = new BrokerClient(new MockBrokerServiceLocatorMultiPartition())
+            {
+                QueueStatCapacity = 2
+            };
+            await brokerClient.GetBrokerStatsAsync();
+            await brokerClient.GetBrokerStatsAsync();
+            var queueStats = await brokerClient.GetBrokerStatsAsync();
+            Assert.IsTrue(queueStats.Count == 2);
+            Assert.IsTrue(queueStats.ContainsKey("MessageOneQueue") && queueStats["MessageOneQueue"].Count == 2 && queueStats["MessageOneQueue"].First().TotalDelivered == 39);
+            Assert.IsTrue(queueStats.ContainsKey("MessageTwoQueue") && queueStats["MessageTwoQueue"].Count == 2 && queueStats["MessageTwoQueue"].First().TotalReceived == 510);
+        }
+
+        [TestMethod]
+        public async Task WhenUnsubscribeByQueueName_UnsubscribeIsCalledWithTheRightReferenceWrapper()
+        {
+            var brokerService = new MockBrokerServicePartitionOne();
+            var brokerClient = new BrokerClient(new MockBrokerServiceLocatorMultiPartition(new List<IBrokerService> { brokerService }));
+            await brokerClient.UnsubscribeByQueueNameAsync("MessageOneQueue");
+            Assert.IsTrue(brokerService.UnsubscribeMessageTypeName == "MessageOneQueue");
+            Assert.IsInstanceOfType(brokerService.UnsubscribeReference, typeof(ServiceReferenceWrapper));
+        }
+    }
+
+    internal class MockBrokerServiceLocatorMultiPartition : MockBrokerServiceLocator
+    {
+        private readonly List<IBrokerService> _brokers;
+
+        public MockBrokerServiceLocatorMultiPartition(List<IBrokerService> brokers = null)
+        {
+            _brokers = brokers ?? new List<IBrokerService>
+            {
+                new MockBrokerServicePartitionOne(),
+                new MockBrokerServicePartitionTwo()
+            };
+        }
+        public override Task<IEnumerable<IBrokerService>> GetBrokerServicesForAllPartitionsAsync(Uri brokerServiceName = null)
+        {
+            return Task.FromResult<IEnumerable<IBrokerService>>(_brokers);
+        }
+
+        public override Task<IBrokerService> GetBrokerServiceForMessageAsync(string messageTypeName, Uri brokerServiceName = null)
+        {
+            return Task.FromResult(_brokers.First());
+        }
+    }
+
+    internal class MockBrokerServicePartitionOne : MockBrokerService
+    {
+        private ulong _totalDelivered = 29;
+        private ulong _totalReceived = 45;
+
+        public override Task<QueueStatsWrapper> GetBrokerStatsAsync()
+        {
+            _totalDelivered += 5;
+            _totalReceived += 5;
+            return Task.FromResult(new QueueStatsWrapper
+            {
+                Queues = new Dictionary<string, ReferenceWrapper>
+                {
+                    { "MessageOneQueue", new ServiceReferenceWrapper(new ServiceReference()) }
+                },
+                Stats =  new List<QueueStats>
+                {
+                    new QueueStats
+                    {
+                        QueueName = "MessageOneQueue",
+                        Time = new DateTime(2000, 1, 1, 12, 0, 0),
+                        TotalDelivered = _totalDelivered,
+                        TotalReceived = _totalReceived
+                    }
+                }
+            });
+        }
+
+        public override Task UnsubscribeAsync(ReferenceWrapper reference, string messageTypeName)
+        {
+            UnsubscribeReference = reference;
+            UnsubscribeMessageTypeName = messageTypeName;
+
+            return Task.CompletedTask;
+        }
+
+        public string UnsubscribeMessageTypeName { get; set; }
+
+        public ReferenceWrapper UnsubscribeReference { get; set; }
+    }
+
+    internal class MockBrokerServicePartitionTwo : MockBrokerService
+    {
+        private ulong _totalDelivered = 644;
+        private ulong _totalReceived = 490;
+
+        public override Task<QueueStatsWrapper> GetBrokerStatsAsync()
+        {
+            _totalDelivered += 10;
+            _totalReceived += 10;
+            return Task.FromResult(new QueueStatsWrapper
+            {
+                Queues = new Dictionary<string, ReferenceWrapper>
+                {
+                    { "MessageTwoQueue", new ServiceReferenceWrapper(new ServiceReference()) }
+                },
+                Stats =  new List<QueueStats>
+                {
+                    new QueueStats
+                    {
+                        QueueName = "MessageTwoQueue",
+                        Time = new DateTime(2000, 1, 1, 12, 0, 0),
+                        TotalDelivered = _totalDelivered,
+                        TotalReceived = _totalReceived
+                    }
+                }
+            });
+        }
+    }
+}

--- a/ServiceFabric.PubSubActors.Tests/MockBrokerServiceLocator.cs
+++ b/ServiceFabric.PubSubActors.Tests/MockBrokerServiceLocator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ServiceFabric.PubSubActors.Helpers;
 using ServiceFabric.PubSubActors.State;
@@ -22,9 +23,17 @@ namespace ServiceFabric.PubSubActors.Tests
             return Task.FromResult<IBrokerService>(new MockBrokerService());
         }
 
-        public Task<IBrokerService> GetBrokerServiceForMessageAsync(string messageTypeName, Uri brokerServiceName = null)
+        public virtual Task<IBrokerService> GetBrokerServiceForMessageAsync(string messageTypeName, Uri brokerServiceName = null)
         {
             return Task.FromResult<IBrokerService>(new MockBrokerService());
+        }
+
+        public virtual Task<IEnumerable<IBrokerService>> GetBrokerServicesForAllPartitionsAsync(Uri brokerServiceName = null)
+        {
+            return Task.FromResult<IEnumerable<IBrokerService>>(new List<IBrokerService>
+            {
+                new MockBrokerService()
+            });
         }
     }
 
@@ -35,7 +44,7 @@ namespace ServiceFabric.PubSubActors.Tests
             return Task.CompletedTask;
         }
 
-        public Task UnsubscribeAsync(ReferenceWrapper reference, string messageTypeName)
+        public virtual Task UnsubscribeAsync(ReferenceWrapper reference, string messageTypeName)
         {
             return Task.CompletedTask;
         }
@@ -43,6 +52,15 @@ namespace ServiceFabric.PubSubActors.Tests
         public Task PublishMessageAsync(MessageWrapper message)
         {
             return Task.CompletedTask;
+        }
+
+        public virtual Task<QueueStatsWrapper> GetBrokerStatsAsync()
+        {
+            return Task.FromResult(new QueueStatsWrapper
+            {
+                Queues = new Dictionary<string, ReferenceWrapper>(),
+                Stats = new List<QueueStats>()
+            });
         }
     }
 }

--- a/ServiceFabric.PubSubActors/BrokerService.cs
+++ b/ServiceFabric.PubSubActors/BrokerService.cs
@@ -67,6 +67,7 @@ namespace ServiceFabric.PubSubActors
                     if (message.HasValue)
                     {
                         await subscriber.PublishAsync(message.Value);
+                        subscriber.TotalDelivered++;
                     }
                 }, cancellationToken: cancellationToken);
             }

--- a/ServiceFabric.PubSubActors/BrokerService.cs
+++ b/ServiceFabric.PubSubActors/BrokerService.cs
@@ -67,7 +67,7 @@ namespace ServiceFabric.PubSubActors
                     if (message.HasValue)
                     {
                         await subscriber.PublishAsync(message.Value);
-                        subscriber.TotalDelivered++;
+                        await StatsCollector.OnMessageDelivered(subscriber, message.Value);
                     }
                 }, cancellationToken: cancellationToken);
             }

--- a/ServiceFabric.PubSubActors/BrokerServiceUnordered.cs
+++ b/ServiceFabric.PubSubActors/BrokerServiceUnordered.cs
@@ -67,7 +67,7 @@ namespace ServiceFabric.PubSubActors
                     if (result.HasValue)
                     {
                         await subscriber.PublishAsync(result.Value);
-                        subscriber.TotalDelivered++;
+                        await StatsCollector.OnMessageDelivered(subscriber, result.Value);
                     }
                 }, cancellationToken: cancellationToken);
             }

--- a/ServiceFabric.PubSubActors/BrokerServiceUnordered.cs
+++ b/ServiceFabric.PubSubActors/BrokerServiceUnordered.cs
@@ -67,6 +67,7 @@ namespace ServiceFabric.PubSubActors
                     if (result.HasValue)
                     {
                         await subscriber.PublishAsync(result.Value);
+                        subscriber.TotalDelivered++;
                     }
                 }, cancellationToken: cancellationToken);
             }

--- a/ServiceFabric.PubSubActors/Helpers/IBrokerClient.cs
+++ b/ServiceFabric.PubSubActors/Helpers/IBrokerClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ServiceFabric.PubSubActors.State;
 
@@ -36,5 +37,20 @@ namespace ServiceFabric.PubSubActors.Helpers
         /// <param name="messageWrapper"></param>
         /// <returns></returns>
         Task ProcessMessageAsync(MessageWrapper messageWrapper);
+
+        /// <summary>
+        /// Get the current stats from the Broker for each queue.  Includes information on how many messages have been
+        /// received and delivered.
+        /// </summary>
+        /// <returns></returns>
+        Task<Dictionary<string, List<QueueStats>>> GetBrokerStatsAsync();
+
+        /// <summary>
+        /// Deletes the queue <paramref name="queueName"/> from the Broker.  Useful for a Broker Monitor service to unsubscribe
+        /// a service or actor from a message type.  The queueName can be found with a call to <see cref="GetBrokerStatsAsync"/>.
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <returns></returns>
+        Task UnsubscribeByQueueNameAsync(string queueName);
     }
 }

--- a/ServiceFabric.PubSubActors/Helpers/IBrokerServiceLocator.cs
+++ b/ServiceFabric.PubSubActors/Helpers/IBrokerServiceLocator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.ServiceFabric.Services.Client;
 
 namespace ServiceFabric.PubSubActors.Helpers
 {
@@ -34,5 +34,12 @@ namespace ServiceFabric.PubSubActors.Helpers
         /// <param name="brokerServiceName">Uri of BrokerService instance</param>
         /// <returns></returns>
         Task<IBrokerService> GetBrokerServiceForMessageAsync(string messageTypeName, Uri brokerServiceName = null);
+
+        /// <summary>
+        /// Gets a collection of <see cref="IBrokerService"/> ServiceProxy instances, one for each partition.
+        /// </summary>
+        /// <param name="brokerServiceName"></param>
+        /// <returns></returns>
+        Task<IEnumerable<IBrokerService>> GetBrokerServicesForAllPartitionsAsync(Uri brokerServiceName = null);
     }
 }

--- a/ServiceFabric.PubSubActors/IBrokerService.cs
+++ b/ServiceFabric.PubSubActors/IBrokerService.cs
@@ -29,5 +29,12 @@ namespace ServiceFabric.PubSubActors
         /// <param name="message">The message to publish</param>
         /// <returns></returns>
         Task PublishMessageAsync(MessageWrapper message);
+
+        /// <summary>
+        /// Returns a list of <see cref="QueueStats"/> objects providing the total number of messages received and
+        /// delivered for each queue.
+        /// </summary>
+        /// <returns></returns>
+        Task<QueueStatsWrapper> GetBrokerStatsAsync();
     }
 }

--- a/ServiceFabric.PubSubActors/ServiceFabric.PubSubActors.csproj
+++ b/ServiceFabric.PubSubActors/ServiceFabric.PubSubActors.csproj
@@ -3,7 +3,7 @@
     <Description>ServiceFabric.PubSubActors adds pub/sub behaviour to your Reliable Actors and Services in Service Fabric. How to use this package: https://github.com/loekd/ServiceFabric.PubSubActors/blob/master/README.md</Description>
     <Copyright>2019</Copyright>
     <AssemblyTitle>ServiceFabric.PubSubActors</AssemblyTitle>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <Authors>Loek Duys</Authors>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/ServiceFabric.PubSubActors/State/BrokerStats.cs
+++ b/ServiceFabric.PubSubActors/State/BrokerStats.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace ServiceFabric.PubSubActors.State
+{
+    public class BrokerStats
+    {
+        public Dictionary<string, ReferenceWrapper> Subscribers { get; set; }
+        public Dictionary<string, List<QueueStats>> QueueStats { get; set; }
+    }
+}

--- a/ServiceFabric.PubSubActors/State/QueueStats.cs
+++ b/ServiceFabric.PubSubActors/State/QueueStats.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace ServiceFabric.PubSubActors.State
+{
+    [DataContract]
+    public class QueueStats
+    {
+        [DataMember]
+        public string QueueName { get; set; }
+        [DataMember]
+        public string ServiceName { get; set; }
+        [DataMember]
+        public DateTime Time { get; set; }
+        [DataMember]
+        public ulong TotalReceived { get; set; }
+        [DataMember]
+        public ulong TotalDelivered { get; set; }
+    }
+
+    [DataContract]
+    public class QueueStatsWrapper
+    {
+        [DataMember]
+        public Dictionary<string, ReferenceWrapper> Queues { get; set; }
+        [DataMember]
+        public IEnumerable<QueueStats> Stats { get; set; }
+    }
+}

--- a/ServiceFabric.PubSubActors/State/ReferenceWrapper.cs
+++ b/ServiceFabric.PubSubActors/State/ReferenceWrapper.cs
@@ -36,6 +36,9 @@ namespace ServiceFabric.PubSubActors.State
         /// <summary>
         /// Gets a logical name for this reference
         /// </summary>
+        public ulong TotalReceived { get; set; }
+        public ulong TotalDelivered { get; set; }
+
         public abstract string Name { get; }
 
         /// <summary>

--- a/ServiceFabric.PubSubActors/Stats/IStatsCollector.cs
+++ b/ServiceFabric.PubSubActors/Stats/IStatsCollector.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using ServiceFabric.PubSubActors.State;
+
+namespace ServiceFabric.PubSubActors.Stats
+{
+    public interface IStatsCollector
+    {
+        Task OnMessageReceived(ReferenceWrapper subscriber, MessageWrapper messageWrapper);
+        Task OnMessageDelivered(ReferenceWrapper subscriber, MessageWrapper messageWrapper);
+    }
+}

--- a/ServiceFabric.PubSubActors/Stats/StatsCollector.cs
+++ b/ServiceFabric.PubSubActors/Stats/StatsCollector.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using ServiceFabric.PubSubActors.State;
+
+namespace ServiceFabric.PubSubActors.Stats
+{
+    public class StatsCollector : IStatsCollector
+    {
+        public Task OnMessageReceived(ReferenceWrapper subscriber, MessageWrapper messageWrapper)
+        {
+            subscriber.TotalReceived++;
+            return Task.FromResult(true);
+        }
+
+        public Task OnMessageDelivered(ReferenceWrapper subscriber, MessageWrapper messageWrapper)
+        {
+            subscriber.TotalDelivered++;
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
Added some functionality to provide some basic insight into the state of the BrokerService.  Related to issue #39.

* Created two counters in the ReferenceWrapper to record the total number of messages received and delivered for each queue.
* Added endpoint to the BrokerService to allow external services to poll for Broker stats, including a list of all subscribers and the current totals for each queue.
* Added method to BrokerClient to consume the GetBrokerStats() endpoint.  Calls all partitions of the BrokerService and aggregates the results.
* Added method to BrokerClient to unsubscribe a service by queue name.
