### PR TITLE
Throttle processing during failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# 9.1.0 (2019-03-26)
+# 9.1.0 (2019-04-01)
 ### Features
 * **Subscribe Retry**: Added a retry strategy for when a subscriber fails to subscribe because the Broker doesn't exist yet.
 * **BrokerServiceUri**: We recently lost the ability to specify the BrokerUri when publishing/subscribing.  Added the ability to pass the BrokerUri to the BrokerServiceLocator class.
+* **Throttle on Failure**: Added a config to slow down the processing loop when errors occur.
+* **Filter Broker Stats**: Added ability to filter on time, Service name, or message type using query parameters in the GET broker/stats API in the demo app.
 
 # 9.0.0 (2019-03-21)
 ### Features

--- a/src/SoCreate.ServiceFabric.PubSub/BrokerService.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/BrokerService.cs
@@ -76,7 +76,7 @@ namespace SoCreate.ServiceFabric.PubSub
                         }
                         catch (Exception ex)
                         {
-                            await BrokerEventsManager.OnMessageDeliveryFailedAsync(queueName, subscriber, message.Value, ex);
+                            await BrokerEventsManager.OnMessageDeliveryFailedAsync(queueName, subscriber, message.Value, ex, ThrottleFactor);
                             throw;
                         }
                     }

--- a/src/SoCreate.ServiceFabric.PubSub/BrokerServiceBase.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/BrokerServiceBase.cs
@@ -53,12 +53,12 @@ namespace SoCreate.ServiceFabric.PubSub
         protected TimeSpan DueTime { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
-        /// Gets or sets the interval to wait between batches of publishing messages. (Default: 5s)
+        /// Gets or sets the interval to wait between batches of publishing messages. (Default: 1s)
         /// </summary>
         protected TimeSpan Period { get; set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
-        /// Gets or sets the interval to wait between batches of publishing messages. (Default: 5s)
+        /// Gets or sets the amount to throttle queue processing when deliveries are failing.  Slow down queue processing by a factor of X. (Default 10) (Default: 10)
         /// </summary>
         protected int ThrottleFactor { get; set; } = 10;
 

--- a/src/SoCreate.ServiceFabric.PubSub/Events/DefaultBrokerEventsManager.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Events/DefaultBrokerEventsManager.cs
@@ -56,12 +56,14 @@ namespace SoCreate.ServiceFabric.PubSub.Events
             _stats[queueName].TotalDelivered++;
         }
 
-        public async Task OnMessageDeliveryFailedAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper, Exception exception)
+        public async Task OnMessageDeliveryFailedAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper, Exception exception, int throttleFactor)
         {
             if (MessageDeliveryFailed != null)
             {
                 await MessageDeliveryFailed.Invoke(queueName, subscriber, messageWrapper, exception);
             }
+
+            subscriber.SkipCount = throttleFactor;
             _stats[queueName].TotalDeliveryFailures++;
         }
 

--- a/src/SoCreate.ServiceFabric.PubSub/Events/IBrokerEvents.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Events/IBrokerEvents.cs
@@ -20,7 +20,7 @@ namespace SoCreate.ServiceFabric.PubSub.Events
         Task OnUnsubscribedAsync(string queueName, ReferenceWrapper subscriber, string messageTypeName);
         Task OnMessageReceivedAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper);
         Task OnMessageDeliveredAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper);
-        Task OnMessageDeliveryFailedAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper, Exception exception);
+        Task OnMessageDeliveryFailedAsync(string queueName, ReferenceWrapper subscriber, MessageWrapper messageWrapper, Exception exception, int throttleFactor = 0);
         Task<List<QueueStats>> GetStatsAsync();
     }
 }

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -44,6 +44,8 @@ namespace SoCreate.ServiceFabric.PubSub.State
         [DataMember]
         public string RoutingKey { get; private set; }
 
+        public int SkipCount { get; set; }
+
         /// <inheritdoc />
         public abstract bool Equals(ReferenceWrapper other);
 
@@ -97,6 +99,16 @@ namespace SoCreate.ServiceFabric.PubSub.State
             string value = (string)token.SelectToken(_routingKeyValue[0]);
 
             return string.Equals(_routingKeyValue[1], value, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public bool ShouldProcessMessages()
+        {
+            if (SkipCount > 0)
+            {
+                SkipCount--;
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Added ThrottleFactor configuration to slow down processing when delivery failures occur.

Updated `BrokerClient.UnsubscribeByQueueName()` to not save stats.
Added query parameters to filter results of the GET Broker Stats API.