### PR TITLE
Add OnPublishMessageAsync hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.1.1 (2019-05-29)
+### Features
+* **OnPublishMessageAsync**: Added extension point in BrokerServiceBase class to do actions before or after the events have been published to the subscribers.
+
 # 9.1.0 (2019-04-01)
 ### Features
 * **Subscribe Retry**: Added a retry strategy for when a subscriber fails to subscribe because the Broker doesn't exist yet.

--- a/src/SoCreate.ServiceFabric.PubSub/BrokerServiceBase.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/BrokerServiceBase.cs
@@ -189,7 +189,9 @@ namespace SoCreate.ServiceFabric.PubSub
                 await BrokerEventsManager.OnUnsubscribedAsync(queueName, reference, messageTypeName);
             });
         }
-
+        
+        protected virtual Task OnPublishMessageAsync(MessageWrapper message) { return Task.CompletedTask; }
+        
         /// <summary>
         /// Takes a published message and forwards it (indirectly) to all Subscribers.
         /// </summary>
@@ -198,6 +200,8 @@ namespace SoCreate.ServiceFabric.PubSub
         public async Task PublishMessageAsync(MessageWrapper message)
         {
             await WaitForInitializeAsync(CancellationToken.None);
+
+            await OnPublishMessageAsync(message);
 
             var myDictionary = await TimeoutRetryHelper.Execute((token, state) => StateManager.GetOrAddAsync<IReliableDictionary<string, BrokerServiceState>>(message.MessageType));
 

--- a/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
+++ b/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
@@ -3,7 +3,7 @@
     <Description>SoCreate.ServiceFabric.PubSub adds pub/sub behaviour to your Reliable Actors and Services in Service Fabric. Documentation: http://service-fabric-pub-sub.socreate.it</Description>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
     <AssemblyTitle>SoCreate.ServiceFabric.PubSub</AssemblyTitle>
-    <Version>9.1.0</Version>
+    <Version>9.1.1</Version>
     <Company>SoCreate</Company>
     <Authors>Loek Duys, SoCreate</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Introduce a new overridable hook to process each published message received by the broker service. This can be used to implement an eventstore like broker, that saves each event to a external database for replay and archive purposes.