### PR TITLE
Use concurrent dictionary to allow concurrent write access to stats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.1.1 (2019-05-28)
+### Bug fix
+* **Broker Stats**: Use concurrent dictionary to allow concurrent write access to stats.
+
 # 9.1.0 (2019-04-01)
 ### Features
 * **Subscribe Retry**: Added a retry strategy for when a subscriber fails to subscribe because the Broker doesn't exist yet.

--- a/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
+++ b/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
@@ -3,7 +3,7 @@
     <Description>SoCreate.ServiceFabric.PubSub adds pub/sub behaviour to your Reliable Actors and Services in Service Fabric. Documentation: http://service-fabric-pub-sub.socreate.it</Description>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
     <AssemblyTitle>SoCreate.ServiceFabric.PubSub</AssemblyTitle>
-    <Version>9.1.0</Version>
+    <Version>9.1.1</Version>
     <Company>SoCreate</Company>
     <Authors>Loek Duys, SoCreate</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenDefaultBrokerEventsManager.cs
+++ b/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenDefaultBrokerEventsManager.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.ServiceFabric.Actors;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SoCreate.ServiceFabric.PubSub.Events;
+using SoCreate.ServiceFabric.PubSub.State;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SoCreate.ServiceFabric.PubSub.Tests
+{
+    [TestClass]
+    public class GivenDefaultBrokerEventsManager
+    {
+        [TestMethod]
+        public async Task WhenInsertingConcurrently_ThenAllCallbacksAreMadeCorrectly()
+        {
+            int callCount = 0;
+            var manager = new DefaultBrokerEventsManager();
+            manager.Subscribed += (s, e, t) =>
+            {
+                lock (manager)
+                {
+                    callCount++;
+                }
+
+                return Task.CompletedTask;
+
+            };
+            const int attempts = 20;
+            var tasks = new List<Task>(attempts);
+
+            for (int i = 0; i < attempts; i++)
+            {
+                var actorReference = new ActorReference{ ActorId =  ActorId.CreateRandom() };
+                tasks.Add(manager.OnSubscribedAsync("Key", new ActorReferenceWrapper(actorReference), "MessageType"));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.AreEqual(attempts, callCount);
+        }
+    }
+}


### PR DESCRIPTION
### Bug fix
* **Broker Stats**: Use concurrent dictionary to allow concurrent write access to stats.