### PR TITLE
routing key bug fix and wild card support

### DIFF
--- a/examples/SoCreate.ServiceFabric.PubSubDemo.SampleStatefulSubscriber/SampleStatefulSubscriber.cs
+++ b/examples/SoCreate.ServiceFabric.PubSubDemo.SampleStatefulSubscriber/SampleStatefulSubscriber.cs
@@ -14,8 +14,12 @@ namespace SoCreate.ServiceFabric.PubSubDemo.SampleStatefulSubscriber
         {
             Logger = message => ServiceEventSource.Current.ServiceMessage(Context, message);
         }
-
-        [Subscribe]
+        /// <summary>
+        /// This Subscription should only get SampleEvents who messages end in a
+        /// </summary>
+        /// <param name="sampleEvent"></param>
+        /// <returns></returns>
+        [Subscribe(routingKeyName: "Message", routingKeyValue: "*1")]
         private Task HandleSampleEvent(SampleEvent sampleEvent)
         {
             ServiceEventSource.Current.ServiceMessage(Context, $"Processing {sampleEvent.GetType()}: {sampleEvent.Message} on SampleStatefulSubscriber");

--- a/src/SoCreate.ServiceFabric.PubSub/BrokerClient.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/BrokerClient.cs
@@ -144,11 +144,12 @@ namespace SoCreate.ServiceFabric.PubSub
         /// <param name="handler"></param>
         /// <param name="isOrdered"></param>
         /// <param name="listenerName"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional Message property path used for routing</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <returns></returns>
-        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatelessService service, Func<T, Task> handler, bool isOrdered = true, string listenerName = null, string routingKey = null) where T : class
+        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatelessService service, Func<T, Task> handler, bool isOrdered = true, string listenerName = null, string routingKeyName = null, string routingKeyValue = null) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKey), typeof(T), handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKeyName, routingKeyValue), typeof(T), handler, isOrdered);
         }
 
         /// <summary>
@@ -159,11 +160,12 @@ namespace SoCreate.ServiceFabric.PubSub
         /// <param name="handler"></param>
         /// <param name="isOrdered"></param>
         /// <param name="listenerName"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <returns></returns>
-        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatefulService service, Func<T, Task> handler, bool isOrdered = true, string listenerName = null, string routingKey = null) where T : class
+        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatefulService service, Func<T, Task> handler, bool isOrdered = true, string listenerName = null, string routingKeyName = null, string routingKeyValue = null) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKey), typeof(T), handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKeyName, routingKeyValue), typeof(T), handler, isOrdered);
         }
 
         /// <summary>
@@ -173,11 +175,12 @@ namespace SoCreate.ServiceFabric.PubSub
         /// <param name="actor"></param>
         /// <param name="handler"></param>
         /// <param name="isOrdered"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <returns></returns>
-        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, ActorBase actor, Func<T, Task> handler, bool isOrdered = true, string routingKey = null) where T : class
+        public static Task SubscribeAsync<T>(this IBrokerClient brokerClient, ActorBase actor, Func<T, Task> handler, bool isOrdered = true, string routingKeyName = null, string routingKeyValue = null) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(actor, routingKey), typeof(T), handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(actor, routingKeyName, routingKeyValue), typeof(T), handler, isOrdered);
         }
 
         /// <summary>
@@ -215,19 +218,19 @@ namespace SoCreate.ServiceFabric.PubSub
 
         // subscribe/unsubscribe using Type (useful when processing Subscribe attributes)
 
-        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatelessService service, Type messageType, Func<T, Task> handler, string listenerName = null, string routingKey = null, bool isOrdered = true) where T : class
+        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatelessService service, Type messageType, Func<T, Task> handler, string listenerName = null, string routingKeyName = null, string routingKeyValue = null, bool isOrdered = true) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKey), messageType, handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKeyName, routingKeyValue), messageType, handler, isOrdered);
         }
 
-        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatefulService service, Type messageType, Func<T, Task> handler, string listenerName = null, string routingKey = null, bool isOrdered = true) where T : class
+        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, StatefulService service, Type messageType, Func<T, Task> handler, string listenerName = null, string routingKeyName = null, string routingKeyValue = null, bool isOrdered = true) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKey), messageType, handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(service, listenerName, routingKeyName, routingKeyValue), messageType, handler, isOrdered);
         }
 
-        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, ActorBase actor, Type messageType, Func<T, Task> handler, string routingKey = null, bool isOrdered = true) where T : class
+        internal static Task SubscribeAsync<T>(this IBrokerClient brokerClient, ActorBase actor, Type messageType, Func<T, Task> handler, string routingKeyname = null, string routingKeyValue = null, bool isOrdered = true) where T : class
         {
-            return brokerClient.SubscribeAsync(CreateReferenceWrapper(actor, routingKey), messageType, handler, isOrdered);
+            return brokerClient.SubscribeAsync(CreateReferenceWrapper(actor, routingKeyname, routingKeyValue), messageType, handler, isOrdered);
         }
 
         internal static Task UnsubscribeAsync(this IBrokerClient brokerClient, StatelessService service, Type messageType)
@@ -250,14 +253,15 @@ namespace SoCreate.ServiceFabric.PubSub
         /// </summary>
         /// <param name="service"></param>
         /// <param name="listenerName"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional Message property path used for routing</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static ReferenceWrapper CreateReferenceWrapper(this StatelessService service, string listenerName = null, string routingKey = null)
+        public static ReferenceWrapper CreateReferenceWrapper(this StatelessService service, string listenerName = null, string routingKeyName = null, string routingKeyValue = null)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             var servicePartition = GetPropertyValue<StatelessService, IServicePartition>(service, "Partition");
-            return new ServiceReferenceWrapper(CreateServiceReference(service.Context, servicePartition.PartitionInfo, listenerName), routingKey);
+            return new ServiceReferenceWrapper(CreateServiceReference(service.Context, servicePartition.PartitionInfo, listenerName), routingKeyName, routingKeyValue);
         }
 
         /// <summary>
@@ -265,27 +269,29 @@ namespace SoCreate.ServiceFabric.PubSub
         /// </summary>
         /// <param name="service"></param>
         /// <param name="listenerName"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
-        /// <returns></returns>
+        /// <param name="routingKeyName">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
+        // <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static ReferenceWrapper CreateReferenceWrapper(this StatefulService service, string listenerName = null, string routingKey = null)
+        public static ReferenceWrapper CreateReferenceWrapper(this StatefulService service, string listenerName = null, string routingKeyName = null, string routingKeyValue = null)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             var servicePartition = GetPropertyValue<StatefulService, IServicePartition>(service, "Partition");
-            return new ServiceReferenceWrapper(CreateServiceReference(service.Context, servicePartition.PartitionInfo, listenerName), routingKey);
+            return new ServiceReferenceWrapper(CreateServiceReference(service.Context, servicePartition.PartitionInfo, listenerName), routingKeyName, routingKeyValue);
         }
 
         /// <summary>
         /// Create a ReferenceWrapper object given this Actor.
         /// </summary>
         /// <param name="actor"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional Message property path used for routing</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static ReferenceWrapper CreateReferenceWrapper(this ActorBase actor, string routingKey = null)
+        public static ReferenceWrapper CreateReferenceWrapper(this ActorBase actor, string routingKeyName = null, string routingKeyValue = null)
         {
             if (actor == null) throw new ArgumentNullException(nameof(actor));
-            return new ActorReferenceWrapper(ActorReference.Get(actor), routingKey);
+            return new ActorReferenceWrapper(ActorReference.Get(actor), routingKeyName, routingKeyValue);
         }
 
         /// <summary>

--- a/src/SoCreate.ServiceFabric.PubSub/State/ActorReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ActorReferenceWrapper.cs
@@ -34,10 +34,11 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// Creates a new instance using the provided <see cref="Microsoft.ServiceFabric.Actors.ActorReference"/>.
         /// </summary>
         /// <param name="actorReference"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKeyName">Optional Message property path used for routing</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
         /// <remarks>Only works when using the <see cref="DefaultPayloadSerializer"/>. Uses <see cref="JToken"/>.SelectToken to find message property.</remarks>
-        public ActorReferenceWrapper(ActorReference actorReference, string routingKey = null)
-            : base(routingKey)
+        public ActorReferenceWrapper(ActorReference actorReference, string routingKeyName = null, string routingKeyValue = null)
+            : base(routingKeyName, routingKeyValue)
         {
             if (actorReference == null) throw new ArgumentNullException(nameof(actorReference));
             if (actorReference.ActorId == null) throw new ArgumentException(nameof(actorReference.ActorId));
@@ -105,7 +106,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <inheritdoc />
         public override Task PublishAsync(MessageWrapper message)
         {
-            if (string.IsNullOrWhiteSpace(RoutingKey) || ShouldDeliverMessage(message))
+            if (string.IsNullOrWhiteSpace(RoutingKeyName) || ShouldDeliverMessage(message))
             {
                 var actor = (ISubscriberActor)ActorReference.Bind(typeof(ISubscriberActor));
                 return actor.ReceiveMessageAsync(message);

--- a/src/SoCreate.ServiceFabric.PubSub/State/ServiceReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ServiceReferenceWrapper.cs
@@ -38,9 +38,10 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// Creates a new instance using the provided <see cref="ServiceReference"/>.
         /// </summary>
         /// <param name="serviceReference"></param>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
-        public ServiceReferenceWrapper(ServiceReference serviceReference, string routingKey = null)
-            : base(routingKey)
+        /// <param name="routingKeyName">Optional Message property path used for routing</param>
+        /// <param name="routingKeyValue">Optional value to match with message payload content used for routing.</param>
+        public ServiceReferenceWrapper(ServiceReference serviceReference, string routingKeyName = null, string routingKeyValue= null)
+            : base(routingKeyName, routingKeyValue)
         {
             ServiceReference = serviceReference ?? throw new ArgumentNullException(nameof(serviceReference));
         }
@@ -122,7 +123,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <inheritdoc />
         public override Task PublishAsync(MessageWrapper message)
         {
-            if (string.IsNullOrWhiteSpace(RoutingKey) || ShouldDeliverMessage(message))
+            if (string.IsNullOrWhiteSpace(RoutingKeyName) || ShouldDeliverMessage(message))
             {
                 ServicePartitionKey partitionKey;
                 switch (ServiceReference.PartitionKind)

--- a/src/SoCreate.ServiceFabric.PubSub/Subscriber/StatefulSubscriberServiceBootstrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Subscriber/StatefulSubscriberServiceBootstrapper.cs
@@ -128,7 +128,8 @@ namespace SoCreate.ServiceFabric.PubSub.Subscriber
                         _service,
                         subscription.Key,
                         subscribeAttribute.Handler,
-                        routingKey: subscribeAttribute.RoutingKey,
+                        routingKeyName: subscribeAttribute.RoutingKeyName,
+                        routingKeyValue: subscribeAttribute.RoutingKeyValue,
                         isOrdered: subscribeAttribute.QueueType == QueueType.Ordered)
                         .ConfigureAwait(false);
                 }

--- a/src/SoCreate.ServiceFabric.PubSub/Subscriber/StatelessSubscriberServiceBootstrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Subscriber/StatelessSubscriberServiceBootstrapper.cs
@@ -128,7 +128,8 @@ namespace SoCreate.ServiceFabric.PubSub.Subscriber
                         _service,
                         subscription.Key,
                         subscribeAttribute.Handler,
-                        routingKey: subscribeAttribute.RoutingKey,
+                        routingKeyName: subscribeAttribute.RoutingKeyName,
+                        routingKeyValue: subscribeAttribute.RoutingKeyValue,
                         isOrdered: subscribeAttribute.QueueType == QueueType.Ordered)
                         .ConfigureAwait(false);
                 }

--- a/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberExtensions.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberExtensions.cs
@@ -16,14 +16,16 @@ namespace SoCreate.ServiceFabric.PubSub.Subscriber
     {
         public QueueType QueueType { get; }
 
-        public string RoutingKey { get; }
-        
+        public string RoutingKeyName { get; }
+        public string RoutingKeyValue { get; }
+
         public Func<object, Task> Handler { get; set; }
         
-        public SubscribeAttribute(QueueType type = QueueType.Ordered, string routingKey = null)
+        public SubscribeAttribute(QueueType type = QueueType.Ordered, string routingKeyName = null, string routingKeyValue = null)
         {
             QueueType = type;
-            RoutingKey = routingKey;
+            RoutingKeyName = routingKeyName;
+            RoutingKeyValue = routingKeyValue;
         }
     }
 

--- a/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberStatefulServiceBase.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberStatefulServiceBase.cs
@@ -101,7 +101,8 @@ namespace SoCreate.ServiceFabric.PubSub.Subscriber
                         subscription.Key,
                         subscribeAttribute.Handler,
                         ListenerName,
-                        subscribeAttribute.RoutingKey,
+                        subscribeAttribute.RoutingKeyName,
+                        subscribeAttribute.RoutingKeyValue,
                         subscribeAttribute.QueueType == QueueType.Ordered);
                     LogMessage($"Registered Service:'{Context.ServiceName}' as Subscriber of {subscription.Key}.");
                 }

--- a/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberStatelessServiceBase.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/Subscriber/SubscriberStatelessServiceBase.cs
@@ -86,7 +86,8 @@ namespace SoCreate.ServiceFabric.PubSub.Subscriber
                         subscription.Key,
                         subscribeAttribute.Handler,
                         ListenerName,
-                        subscribeAttribute.RoutingKey,
+                        subscribeAttribute.RoutingKeyName,
+                        subscribeAttribute.RoutingKeyValue,
                         subscribeAttribute.QueueType == QueueType.Ordered);
                     LogMessage($"Registered Service:'{Context.ServiceName}' as Subscriber of {subscription.Key}.");
                 }

--- a/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReference.cs
+++ b/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReference.cs
@@ -10,7 +10,7 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
         [TestMethod]
         public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayload_ThenReturnsTrue()
         {
-            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name=Customer1");
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "Customer1");
             var messageWrapper = new
             {
                 Customer = new
@@ -26,7 +26,7 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
         [TestMethod]
         public void WhenDeterminingShouldDeliverMessageToServiceWithUnmatchingPayload_ThenReturnsFalse()
         {
-            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name=Customer1");
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "Customer1");
             var messageWrapper = new
             {
                 Customer = new
@@ -42,7 +42,7 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
         [TestMethod]
         public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayload_ThenReturnsFalse()
         {
-            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name=Customer1");
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name" , "Customer1");
             var messageWrapper = new
             {
                 Customer = new
@@ -53,6 +53,247 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
 
             bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
             Assert.IsFalse(shouldDeliver);
+        }
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayload_ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "Customer1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        /// Testing Wild Card Support 
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayloadWithWildCard_ThenReturnsTrue()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithWildCard_ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+
+
+        /// Testing Starting Character Wild Card Support
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayloadWithStartingWildCard_ThenReturnsTrue()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "*1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithUnmatchingPayloadWithStartingWildCard__ThenReturnsFalse()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "*1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithStartingWildCard__ThenReturnsFalse()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "*1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithStartingWildCard__ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "*1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        /// Testing Ending Character Wild Card Support
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayloadWithEndingWildCard_ThenReturnsTrue()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "Customer*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithUnmatchingPayloadWithEndingWildCard__ThenReturnsFalse()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "Supplier*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithEndingWildCard__ThenReturnsFalse()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "Supplier*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithEndingWildCard__ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "Customer*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        /// Testing Multiple Character Wild Card Support
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayloadWithMultipleWildCard_ThenReturnsTrue()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "*Customer*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithUnmatchingPayloadWithMultipleWildCard__ThenReturnsFalse()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name", "*Supplier*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithMultipleWildCard__ThenReturnsFalse()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "*Supplier*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer2"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnmatchingPayloadWithMultipleWildCard__ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name", "*Customer*");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
         }
     }
 }

--- a/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReferenceWrapper.cs
+++ b/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReferenceWrapper.cs
@@ -13,7 +13,7 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
         [TestMethod]
         public void WhenDeserializing_ThenHashingHelperIsNotNull()
         {
-            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A=B");
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A", "B");
             var serializer = new DataContractSerializer(typeof(ServiceReferenceWrapper));
             using (var stream = new MemoryStream())
             {
@@ -33,7 +33,7 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
         [TestMethod]
         public void WhenDeserializing_ThenRoutingKeyIsPreserved()
         {
-            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A=B");
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A", "B");
             var serializer = new DataContractSerializer(typeof(ServiceReferenceWrapper));
             using (var stream = new MemoryStream())
             {
@@ -41,14 +41,15 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
                 stream.Position = 0;
 
                 var cloneServiceRef = (ServiceReferenceWrapper)serializer.ReadObject(stream);
-                Assert.AreEqual("A=B", cloneServiceRef.RoutingKey);
+                Assert.AreEqual("A", cloneServiceRef.RoutingKeyName);
+                Assert.AreEqual("B", cloneServiceRef.RoutingKeyValue);
             }
         }
 
         [TestMethod]
         public void WhenDeserializing_ThenNameIsPreserved()
         {
-            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A=B");
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "A", "B");
             var serializer = new DataContractSerializer(typeof(ServiceReferenceWrapper));
             using (var stream = new MemoryStream())
             {


### PR DESCRIPTION
https://github.com/SoCreate/service-fabric-pub-sub/issues/94

Replace RoutingKey with RoutingKeyName and RoutingKeyValue. If RoutingKeyValue is not null but RoutingKeyName is null, a invalid argument exception is thrown. This seems like the best option. The only other thing that I thought of was maybe using a tuple instead of two different properties.


https://github.com/SoCreate/service-fabric-pub-sub/issues/93

Added wildcard support for RoutingKeyValue by using a regex in ShouldDeliverMessage(). Added test methods for wildcard support.
