### PR TITLE
Service Reference routingkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 12.2.0 (2020-06-23)
+Big thanks to @Calidus for contributing this feature and bug fix!
+### Features
+* **RoutingKey**: RoutingKey value is now a Regex to provide more flexibility.
+### Bug Fix
+* **RoutingKey**: ReferenceWrapper was updated to properly serialize the RoutingKey.
+
 # 12.1.0 (2020-06-03)
 ### Dependencies
 * **Nuget**: Upgraded nuget packages (SF 4.1.409).

--- a/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
+++ b/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
@@ -3,7 +3,7 @@
     <Description>SoCreate.ServiceFabric.PubSub adds pub/sub behaviour to your Reliable Actors and Services in Service Fabric. Documentation: http://service-fabric-pub-sub.socreate.it</Description>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
     <AssemblyTitle>SoCreate.ServiceFabric.PubSub</AssemblyTitle>
-    <Version>12.1.0</Version>
+    <Version>12.2.0</Version>
     <Company>SoCreate</Company>
     <Authors>Loek Duys, SoCreate</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/SoCreate.ServiceFabric.PubSub/State/ActorReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ActorReferenceWrapper.cs
@@ -105,7 +105,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <inheritdoc />
         public override Task PublishAsync(MessageWrapper message)
         {
-            if (string.IsNullOrWhiteSpace(RoutingKey) || ShouldDeliverMessage(message))
+            if (ShouldDeliverMessage(message))
             {
                 var actor = (ISubscriberActor)ActorReference.Bind(typeof(ISubscriberActor));
                 return actor.ReceiveMessageAsync(message);

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -61,9 +61,15 @@ namespace SoCreate.ServiceFabric.PubSub.State
         protected ReferenceWrapper(string routingKey = null)
         {
             var routingKeyArray = routingKey?.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
-            if (routingKeyArray != null && routingKeyArray.Length != 2) throw new ArgumentException($"When {nameof(routingKey)} is provided, it must be similar to 'Key=Value'.");
-            RoutingKeyName = routingKeyArray[0];
-            RoutingKeyValue = routingKeyArray[1];
+            if (!(routingKeyArray is null) && routingKeyArray.Length != 2)
+            {
+                throw new ArgumentException($"When {nameof(routingKey)} is provided, it must be similar to 'Key=Value'.");
+            }
+            else if (routingKeyArray is object)
+            {
+                RoutingKeyName = routingKeyArray[0];
+                RoutingKeyValue = routingKeyArray[1];
+            }
         }
 
         /// <summary>

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -95,7 +95,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
         }
 
         /// <summary>
-        /// Determines whether to deliver the message to the subscriber, based on <see cref="RoutingKeyName"/> and <see cref="MessageWrapper.Payload"/>.
+        /// Determines whether to deliver the message to the subscriber, based on <see cref="RoutingKeyName"/>, <see cref="RoutingKeyValue"/> and <see cref="MessageWrapper.Payload"/>.
         /// Not intended to be called from user code.
         /// </summary>
         /// <param name="message"></param>

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -96,9 +96,10 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <returns></returns>
         public bool ShouldDeliverMessage(MessageWrapper message)
         {
+            if (string.IsNullOrWhiteSpace(RoutingKeyName))
+                return true;
             if (!(MessageWrapperExtensions.PayloadSerializer is DefaultPayloadSerializer))
                 return true;
-
             var token = MessageWrapperExtensions.PayloadSerializer.Deserialize<JToken>(message.Payload);
             string value = (string)token.SelectToken(RoutingKeyName);
 

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -57,16 +57,19 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <summary>
         /// Creates a new instance with an optional routing key.
         /// </summary>
-        /// <param name="routingKey">Optional routing key to filter messages based on content. 'Key=Value' where Key is a message property path and Value is the value to match with message payload content.</param>
+        /// <param name="routingKey">
+        /// Optional routing key to filter messages based on content.
+        /// 'Name=Value' where Name is a message property path and Value is the value to match with message payload content.
+        /// </param>
         protected ReferenceWrapper(string routingKey = null)
         {
             var routingKeyArray = routingKey?.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
-            if (!(routingKeyArray is null) && routingKeyArray.Length != 2)
+            if (!(routingKeyArray is null))
             {
-                throw new ArgumentException($"When {nameof(routingKey)} is provided, it must be similar to 'Key=Value'.");
-            }
-            else if (!(routingKeyArray is null))
-            {
+                if (routingKeyArray.Length != 2)
+                {
+                    throw new ArgumentException($"When {nameof(routingKey)} is provided, it must be similar to 'Key=Value'.");
+                }
                 RoutingKeyName = routingKeyArray[0];
                 RoutingKeyValue = routingKeyArray[1];
             }
@@ -109,7 +112,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
             var token = MessageWrapperExtensions.PayloadSerializer.Deserialize<JToken>(message.Payload);
             string value = (string)token.SelectToken(RoutingKeyName);
 
-            return new Regex(RoutingKeyValue).IsMatch(value);    
+            return new Regex(RoutingKeyValue).IsMatch(value);
         }
 
         public bool ShouldProcessMessages()

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -109,7 +109,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
             var token = MessageWrapperExtensions.PayloadSerializer.Deserialize<JToken>(message.Payload);
             string value = (string)token.SelectToken(RoutingKeyName);
 
-            return string.Equals(RoutingKeyValue, value, StringComparison.InvariantCultureIgnoreCase);
+            return new Regex(RoutingKeyValue).IsMatch(value);    
         }
 
         public bool ShouldProcessMessages()

--- a/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ReferenceWrapper.cs
@@ -65,7 +65,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
             {
                 throw new ArgumentException($"When {nameof(routingKey)} is provided, it must be similar to 'Key=Value'.");
             }
-            else if (routingKeyArray is object)
+            else if (!(routingKeyArray is null))
             {
                 RoutingKeyName = routingKeyArray[0];
                 RoutingKeyValue = routingKeyArray[1];

--- a/src/SoCreate.ServiceFabric.PubSub/State/ServiceReferenceWrapper.cs
+++ b/src/SoCreate.ServiceFabric.PubSub/State/ServiceReferenceWrapper.cs
@@ -122,7 +122,7 @@ namespace SoCreate.ServiceFabric.PubSub.State
         /// <inheritdoc />
         public override Task PublishAsync(MessageWrapper message)
         {
-            if (string.IsNullOrWhiteSpace(RoutingKey) || ShouldDeliverMessage(message))
+            if (ShouldDeliverMessage(message))
             {
                 ServicePartitionKey partitionKey;
                 switch (ServiceReference.PartitionKind)

--- a/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReference.cs
+++ b/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReference.cs
@@ -54,5 +54,86 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
             bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
             Assert.IsFalse(shouldDeliver);
         }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithMatchingPayload_ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name=Customer1");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithMatchingPayloadWithRegex_ThenReturnsTrue()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name=^Customer");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithMatchingPayloadWithRegexReservedChar_ThenReturnsTrue()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name=^Customer");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsTrue(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToServiceWithUnMatchingPayloadWithRegexReservedChar_ThenReturnsFalse()
+        {
+            var serviceRef = new ServiceReferenceWrapper(new ServiceReference(), "Customer.Name=2$");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = serviceRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+
+        [TestMethod]
+        public void WhenDeterminingShouldDeliverMessageToActorWithUnMatchingPayloadWithRegexReservedChar_ThenReturnsFalse()
+        {
+            var actorRef = new ActorReferenceWrapper(new ActorReference { ActorId = ActorId.CreateRandom() }, "Customer.Name=2$");
+            var messageWrapper = new
+            {
+                Customer = new
+                {
+                    Name = "Customer1"
+                }
+            }.CreateMessageWrapper();
+
+            bool shouldDeliver = actorRef.ShouldDeliverMessage(messageWrapper);
+            Assert.IsFalse(shouldDeliver);
+        }
+
     }
 }

--- a/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReferenceWrapper.cs
+++ b/tests/SoCreate.ServiceFabric.PubSub.Tests/GivenServiceReferenceWrapper.cs
@@ -41,7 +41,8 @@ namespace SoCreate.ServiceFabric.PubSub.Tests
                 stream.Position = 0;
 
                 var cloneServiceRef = (ServiceReferenceWrapper)serializer.ReadObject(stream);
-                Assert.AreEqual("A=B", cloneServiceRef.RoutingKey);
+                Assert.AreEqual("A", cloneServiceRef.RoutingKeyName);
+                Assert.AreEqual("B", cloneServiceRef.RoutingKeyValue);
             }
         }
 


### PR DESCRIPTION
Replacement PR For https://github.com/SoCreate/service-fabric-pub-sub/pull/95

Split ```RoutingKey``` into ```RoutingKeyName``` and ```RoutingKeyValue``` in ```ReferenceWrapper```. This should fix issue https://github.com/SoCreate/service-fabric-pub-sub/issues/94. Did not change any interfaces or contracts. Pushed the ```isNullOrWhiteSpace``` check out of ```PublishAsync```and down into ```ShouldDelieverMessage``` to keep all the ```RoutingKeyName``` code together.

```ShouldDelieverMessage``` now converts ```RoutingKeyValue``` into a ```Regex``` and calls ```IsMatch``` instead of using ```string.equals```.  My only concern with this is if someone had used reserved regex characters that need to be escaped in their routing key, this change would only be noticeable at run time. If this is an issue we could add a feature flag to the Subscribe Attribute to toggle between ```string.equals``` and ```Regex.IsMatch```