### PR TITLE
Fix Race Condition In SubscribeAsync and ProcessQueues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.3.1 (2020-11-09)
+### Bug Fix
+* **Issue #90**: Fixed race condition where the process loop can try to start processing a queue before it is created.  Thanks to @BoeseB for reporting this bug. 
+
 # 12.3.0 (2020-07-13)
 Big thanks to @pretyk for contributing this feature!
 ### Features

--- a/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
+++ b/src/SoCreate.ServiceFabric.PubSub/SoCreate.ServiceFabric.PubSub.csproj
@@ -3,7 +3,7 @@
     <Description>SoCreate.ServiceFabric.PubSub adds pub/sub behaviour to your Reliable Actors and Services in Service Fabric. Documentation: http://service-fabric-pub-sub.socreate.it</Description>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
     <AssemblyTitle>SoCreate.ServiceFabric.PubSub</AssemblyTitle>
-    <Version>12.3.0</Version>
+    <Version>12.3.1</Version>
     <Company>SoCreate</Company>
     <Authors>Loek Duys, SoCreate</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Moved adding a new subscription to the local copy to after the transaction creating the queue to avoid a race condition where the process loop starts processing the queue before it is available.

Fixes #90